### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "symfony/twig-bundle": "^3.0",
         "symfony/framework-bundle": "^3.0",
         "symfony/templating": "^2.7|^3.0",
-        "paragonie/random_compat": "^2.0",
         "symfony/security-csrf": "^3.4",
         "psr/log": "~1.0",
         "gree/jose":"2.2.1"


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^2.0`, but also `php: >=7.0.0`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?